### PR TITLE
Cache bundler and build in container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-sudo: required
+sudo: false
 dist: trusty
 
 language: ruby
+cache: bundler
 
 rvm:
   - 2.4.1


### PR DESCRIPTION
Building in container improves startup time of the build (1s vs 20s) and caching bundler counters the slower build in the container; build time stays pretty much the same, but it now starts instantly, so an overall improvement of 20s.