### PR TITLE
Add LogicGraph migration, Reject failed jobs, Overall improvements

### DIFF
--- a/lib/hets-agent/hets.rb
+++ b/lib/hets-agent/hets.rb
@@ -2,5 +2,6 @@
 
 require 'hets-agent/hets/caller'
 require 'hets-agent/hets/analysis_request'
+require 'hets-agent/hets/logic_graph_request'
 require 'hets-agent/hets/version_request'
 require 'hets-agent/hets/response'

--- a/lib/hets-agent/hets/analysis_request.rb
+++ b/lib/hets-agent/hets/analysis_request.rb
@@ -57,8 +57,11 @@ module HetsAgent
       end
 
       def argument_url_catalog
-        urls = url_mappings.map { |source, target| [source, target].join('=') }
-        "--url-catalog=#{urls.join(',')}"
+        substitutions = url_mappings.map do |map|
+          source, target = map.to_a.first
+          [source, target].join('=')
+        end
+        "--url-catalog=#{substitutions.join(',')}"
       end
 
       def argument_file_path
@@ -66,15 +69,17 @@ module HetsAgent
       end
 
       def url_mappings
-        default_url_mappings.merge(@additional_url_mappings)
+        default_url_mappings + @additional_url_mappings
       end
 
       def default_url_mappings
-        url_mappings = {}
+        url_mappings = []
         %w(tree documents).each do |namespace|
-          url_mappings[File.join(server_url, repository_slug, namespace)] =
-            File.join(server_url, repository_slug, 'revision', revision,
-                      namespace)
+          mapping =
+            {File.join(server_url, repository_slug, namespace) =>
+               File.join(server_url, repository_slug, 'revision', revision,
+                         namespace)}
+          url_mappings << mapping
         end
         url_mappings
       end

--- a/lib/hets-agent/hets/caller.rb
+++ b/lib/hets-agent/hets/caller.rb
@@ -9,7 +9,7 @@ module HetsAgent
     class Caller
       def self.call(request)
         HetsAgent::Hets::Response.
-          new(*HetsAgent::Popen.popen(request.arguments))
+          new(request, *HetsAgent::Popen.popen(request.arguments))
       end
     end
   end

--- a/lib/hets-agent/hets/logic_graph_request.rb
+++ b/lib/hets-agent/hets/logic_graph_request.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'hets-agent/hets/request'
+
+module HetsAgent
+  module Hets
+    # Forms a request to export the Logic Graph for Hets
+    class LogicGraphRequest < Request
+      def arguments
+        [
+          hets_path,
+          argument_database_output,
+          argument_database_yml,
+          argument_database_subconfig,
+          '--logic-graph',
+        ]
+      end
+    end
+  end
+end

--- a/lib/hets-agent/hets/request.rb
+++ b/lib/hets-agent/hets/request.rb
@@ -16,6 +16,10 @@ module HetsAgent
       # Override this in the subclass
       def arguments; end
 
+      def to_s
+        arguments.join(' ')
+      end
+
       protected
 
       def argument_database_yml

--- a/lib/hets-agent/hets/response.rb
+++ b/lib/hets-agent/hets/response.rb
@@ -4,9 +4,10 @@ module HetsAgent
   module Hets
     # Forms an response of Hets
     class Response
-      attr_reader :output, :status
+      attr_reader :output, :request, :status
 
-      def initialize(output, status)
+      def initialize(request, output, status)
+        @request = request
         @output = output.strip
         @status = status
       end

--- a/lib/hets-agent/subscriber.rb
+++ b/lib/hets-agent/subscriber.rb
@@ -88,10 +88,14 @@ module HetsAgent
       "hets #{requirement}"
     end
 
+    # rubocop:disable Metrics/MethodLength
     def call_hets(data)
+      # rubocop:enable Metrics/MethodLength
       case data['action']
       when 'analysis'
         call_hets_analysis(data['arguments'])
+      when 'migrate logic-graph'
+        call_hets_logic_graph(data['arguments'])
       when 'version'
         call_hets_version(data['arguments'])
       else
@@ -109,6 +113,10 @@ module HetsAgent
         select { |key, _value| accepted_arguments.include?(key) }
       HetsAgent::Hets::Caller.
         call(HetsAgent::Hets::AnalysisRequest.new(symbolized_arguments))
+    end
+
+    def call_hets_logic_graph(_arguments)
+      HetsAgent::Hets::Caller.call(HetsAgent::Hets::LogicGraphRequest.new)
     end
 
     def call_hets_version(_arguments)

--- a/lib/hets-agent/subscriber.rb
+++ b/lib/hets-agent/subscriber.rb
@@ -84,7 +84,9 @@ module HetsAgent
     def create_worker_queue(requirement)
       channel = @connection.create_channel
       channel.prefetch(1)
-      channel.queue(worker_queue_name(requirement), auto_delete: true)
+      channel.queue(worker_queue_name(requirement),
+                    durable: true,
+                    auto_delete: false)
     end
 
     def worker_queue_name(requirement)

--- a/lib/hets-agent/subscriber.rb
+++ b/lib/hets-agent/subscriber.rb
@@ -59,7 +59,8 @@ module HetsAgent
       return unless version_requirement_satisfied?(requirement)
       queue = create_worker_queue(requirement)
       print_listening(requirement) if print?
-      queue.subscribe(block: false, manual_ack: true,
+      queue.subscribe(block: false,
+                      manual_ack: true,
                       timeout: 0) do |delivery_info, _properties, body|
         handle_job(queue, delivery_info, body)
       end

--- a/lib/hets-agent/subscriber.rb
+++ b/lib/hets-agent/subscriber.rb
@@ -11,6 +11,8 @@ require 'rest-client'
 module HetsAgent
   # Delivers queues for messages and decision which queues should be subscribed
   class Subscriber
+    EXCHANGE_NAME = 'ex_hets_version_requirement'
+
     def initialize(connection = Bunny.new)
       @connection = connection
     end
@@ -33,7 +35,7 @@ module HetsAgent
     # Binds queue to exchange and subscribes to mininmal parsing version queue
     def subscribe_version_requirement_queue
       q_version_requirement = version_requirement_queue
-      q_version_requirement.bind('ex_hets_version_requirement')
+      q_version_requirement.bind(EXCHANGE_NAME)
       q_version_requirement.
         subscribe(block: true,
                   timeout: 0) do |_delivery_info, _properties, requirement|
@@ -44,7 +46,7 @@ module HetsAgent
     # Creates an exchange and a queue for minimal parsing version
     def version_requirement_queue
       channel = @connection.create_channel
-      channel.exchange('ex_hets_version_requirement',
+      channel.exchange(EXCHANGE_NAME,
                        type: 'x-recent-history',
                        durable: true,
                        arguments: {'x-recent-history-length' => 1})

--- a/lib/hets-agent/subscriber.rb
+++ b/lib/hets-agent/subscriber.rb
@@ -62,6 +62,7 @@ module HetsAgent
       queue.subscribe(block: false,
                       manual_ack: true,
                       timeout: 0) do |delivery_info, _properties, body|
+        $stderr.puts "received job: #{body}" if print?
         handle_job(queue, delivery_info, body)
       end
     end

--- a/lib/hets-agent/subscriber.rb
+++ b/lib/hets-agent/subscriber.rb
@@ -59,10 +59,16 @@ module HetsAgent
       print_listening(requirement) if print?
       queue.subscribe(block: false, manual_ack: true,
                       timeout: 0) do |delivery_info, _properties, body|
-        response = call_hets(JSON.parse(body))
-        if response&.status&.zero?
-          queue.channel.acknowledge(delivery_info.delivery_tag)
-        end
+        handle_job(queue, delivery_info, body)
+      end
+    end
+
+    def handle_job(queue, delivery_info, body)
+      response = call_hets(JSON.parse(body))
+      if response&.status&.zero?
+        queue.channel.acknowledge(delivery_info.delivery_tag)
+      else
+        queue.channel.reject(delivery_info.delivery_tag)
       end
     end
 

--- a/spec/lib/hets/analysis_request_spec.rb
+++ b/spec/lib/hets/analysis_request_spec.rb
@@ -20,6 +20,11 @@ describe HetsAgent::Hets::AnalysisRequest do
 
   subject { HetsAgent::Hets::AnalysisRequest.new(arguments) }
 
+  context 'request' do
+    subject { HetsAgent::Hets::LogicGraphRequest.new }
+    it_behaves_like 'a HetsAgent::Hets::Request'
+  end
+
   context 'mocking the system call' do
     before do
       allow_any_instance_of(Kernel).to receive(:system)

--- a/spec/lib/hets/analysis_request_spec.rb
+++ b/spec/lib/hets/analysis_request_spec.rb
@@ -7,22 +7,22 @@ describe HetsAgent::Hets::AnalysisRequest do
     HetsAgent::Application.boot
   end
 
+  let(:arguments) do
+    {
+      revision: '0123456789abcdef0123456789abcdef01234567',
+      file_path: 'Hets-lib/Basic/RelationsAndOrders.casl',
+      file_version_id: 23,
+      repository_slug: 'ada/fixtures',
+      server_url: 'http://localhost:3000',
+      url_mappings: [{'Basic/' => 'Hets-lib/Basic'}],
+    }
+  end
+
+  subject { HetsAgent::Hets::AnalysisRequest.new(arguments) }
+
   context 'mocking the system call' do
     before do
       allow_any_instance_of(Kernel).to receive(:system)
-    end
-
-    subject { HetsAgent::Hets::AnalysisRequest.new(arguments) }
-
-    let(:arguments) do
-      {
-        revision: '0123456789abcdef0123456789abcdef01234567',
-        file_path: 'Hets-lib/Basic/RelationsAndOrders.casl',
-        file_version_id: 23,
-        repository_slug: 'ada/fixtures',
-        server_url: 'http://localhost:3000',
-        url_mappings: {'Basic/' => 'Hets-lib/Basic'},
-      }
     end
 
     it 'has hets as the first argument' do
@@ -72,24 +72,27 @@ describe HetsAgent::Hets::AnalysisRequest do
 
       it 'url catalog' do
         url_mappings =
-          {
-            File.join(arguments[:server_url],
-                      arguments[:repository_slug],
-                      'tree') => File.join(arguments[:server_url],
-                                           arguments[:repository_slug],
-                                           'revision',
-                                           arguments[:revision],
-                                           'tree'),
-            File.join(arguments[:server_url],
-                      arguments[:repository_slug],
-                      'documents') => File.join(arguments[:server_url],
-                                                arguments[:repository_slug],
-                                                'revision',
-                                                arguments[:revision],
-                                                'documents'),
-          }.merge(arguments[:url_mappings])
+          [
+            {File.join(arguments[:server_url],
+                       arguments[:repository_slug],
+                       'tree') => File.join(arguments[:server_url],
+                                            arguments[:repository_slug],
+                                            'revision',
+                                            arguments[:revision],
+                                            'tree')},
+            {File.join(arguments[:server_url],
+                        arguments[:repository_slug],
+                        'documents') => File.join(arguments[:server_url],
+                                                  arguments[:repository_slug],
+                                                  'revision',
+                                                  arguments[:revision],
+                                                  'documents')},
+          ] + arguments[:url_mappings]
         url_catalog =
-          url_mappings.map { |source, target| "#{source}=#{target}" }.join(',')
+          url_mappings.map do |map|
+            source, target = map.to_a.first
+            "#{source}=#{target}"
+          end.join(',')
         expect(subject.arguments).
           to include("--url-catalog=#{url_catalog}")
       end

--- a/spec/lib/hets/logic_graph_request_spec.rb
+++ b/spec/lib/hets/logic_graph_request_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe HetsAgent::Hets::LogicGraphRequest do
+  before do
+    HetsAgent::Application.boot
+  end
+
+  subject { HetsAgent::Hets::LogicGraphRequest.new }
+
+  context 'request' do
+    it_behaves_like 'a HetsAgent::Hets::Request'
+  end
+
+  context 'arguments' do
+    it 'logic graph' do
+      expect(subject.arguments).to include('--logic-graph')
+    end
+
+    it 'output type' do
+      expect(subject.arguments).to include('--output-types=db')
+    end
+
+    it 'database.yml' do
+      database_yml = HetsAgent::Application.root.join('config/database.yml')
+      expect(subject.arguments).
+        to include("--database-config=#{database_yml}")
+    end
+
+    it 'database subconfig' do
+      expect(subject.arguments).
+        to include("--database-subconfig=#{HetsAgent::Application.env}")
+    end
+
+    it 'do not contain anything else' do
+      expect(subject.arguments.length).to eq(5)
+    end
+  end
+end

--- a/spec/lib/hets/response_spec.rb
+++ b/spec/lib/hets/response_spec.rb
@@ -3,9 +3,14 @@
 require 'spec_helper'
 
 describe HetsAgent::Hets::Response do
+  let(:request) { :request }
   let(:output) { 'Lorem ipsum dolor sit' }
   let(:status) { 0 }
-  subject { HetsAgent::Hets::Response.new("#{output}\n", status) }
+  subject { HetsAgent::Hets::Response.new(request, "#{output}\n", status) }
+
+  it 'has the request' do
+    expect(subject.request).to eq(request)
+  end
 
   it 'has a stripped output' do
     expect(subject.output).to eq(output)

--- a/spec/lib/hets/version_request_spec.rb
+++ b/spec/lib/hets/version_request_spec.rb
@@ -7,7 +7,13 @@ describe HetsAgent::Hets::VersionRequest do
     HetsAgent::Application.boot
   end
 
-  context 'arugments' do
+  subject { HetsAgent::Hets::LogicGraphRequest.new }
+
+  context 'request' do
+    it_behaves_like 'a HetsAgent::Hets::Request'
+  end
+
+  context 'arguments' do
     it 'are correct' do
       expect(HetsAgent::Hets::VersionRequest.new.arguments).
         to eq([Settings.hets.path.to_s, '--numeric-version'])

--- a/spec/lib/subscriber_spec.rb
+++ b/spec/lib/subscriber_spec.rb
@@ -14,12 +14,13 @@ describe HetsAgent::Subscriber do
   let(:version_requirement) { '~> 0.1.0' }
   let(:version) { '0.1.5' }
   let(:queue_name) { "hets #{version_requirement}" }
-  let(:hets_response_version) { HetsAgent::Hets::Response.new(version, 0) }
+  let(:request) { double(:request) }
+  let(:hets_response) { HetsAgent::Hets::Response.new(request, version, 0) }
 
   before do
     allow(HetsAgent::Hets::Caller).
       to receive(:call).
-      and_return(hets_response_version)
+      and_return(hets_response)
   end
 
   context 'hets_version' do

--- a/spec/lib/subscriber_spec.rb
+++ b/spec/lib/subscriber_spec.rb
@@ -75,6 +75,21 @@ describe HetsAgent::Subscriber do
         end
       end
 
+      context 'logic graph call' do
+        before do
+          expect(HetsAgent::Hets::Caller).
+            to receive(:call)
+        end
+
+        let(:data) do
+          {action: 'migrate logic-graph'}.to_json
+        end
+
+        it 'receives the message' do
+          session.queues[queue_name].publish(data)
+        end
+      end
+
       context 'analysis call' do
         before do
           allow(HetsAgent::Hets::AnalysisRequest).

--- a/spec/shared_examples/request_spec_shared.rb
+++ b/spec/shared_examples/request_spec_shared.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.shared_examples 'a HetsAgent::Hets::Request' do
+  context 'to_s' do
+    it 'matches the arguments' do
+      expect(subject.to_s).to eq(subject.arguments.join(' '))
+    end
+  end
+
+  context 'arguments' do
+    it 'start with the execuable' do
+      expect(subject.arguments.first).to eq(Settings.hets.path.to_s)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,14 @@ require 'hets-agent'
 require 'bunny-mock'
 require 'support/bunnymock_recent_history_exchange'
 
+Dir.glob('spec/support/**/*.rb').each do |file|
+  require_relative file.sub(%r{\Aspec/}, '')
+end
+
+Dir.glob('spec/shared_examples/**/*.rb').each do |file|
+  require_relative file.sub(%r{\Aspec/}, '')
+end
+
 RSpec.configure do |config|
   config.before(:suite) do
     HetsAgent::Subscriber.new(BunnyMock.new)


### PR DESCRIPTION
This pull request 
* adds a call to migrate the logic graph
* rejects (in contrast to acknowledgements) jobs that have failed
* makes the worker queues durable (i.e. they survive a restart of RabbitMQ)
* adds the request object to a response for more convenient debugging
* uses arrays of single-element hashes for the url mappings instead of just hashes because the same string could be replaced multiple times (e.g. once by the `default_url_mappings` and once by the user-supplied `url_mappings`).