### PR TITLE
Ontohub backend: 181 Add API keys

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,9 @@ hets:
 agent:
   id: 1
 
+backend:
+  api_key: FqeNBVtaNi3D5Bdsgk6_DDCbMqATpsEYxBtx3iZmsfb7y21rHqEXYnXRb3AasEZY
+
 rabbitmq:
   host: localhost
   port: 5672

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -4,6 +4,9 @@ hets:
 agent:
   id: 4711
 
+backend:
+  api_key: test_api_key
+
 rabbitmq:
   host: '::1'
   port: 25672

--- a/lib/hets-agent/hets/analysis_request.rb
+++ b/lib/hets-agent/hets/analysis_request.rb
@@ -28,6 +28,7 @@ module HetsAgent
       def arguments
         [hets_path,
          argument_verbosity,
+         argument_authorization,
          *arguments_database,
          argument_libdirs,
          argument_automatic_rule,

--- a/lib/hets-agent/hets/request.rb
+++ b/lib/hets-agent/hets/request.rb
@@ -22,6 +22,11 @@ module HetsAgent
 
       protected
 
+      def argument_authorization
+        key = Settings.backend.api_key
+        "--http-request-header=Authorization: ApiKey #{key}"
+      end
+
       def arguments_database
         [argument_database_output,
          argument_database_yml,

--- a/spec/lib/hets/analysis_request_spec.rb
+++ b/spec/lib/hets/analysis_request_spec.rb
@@ -41,6 +41,11 @@ describe HetsAgent::Hets::AnalysisRequest do
         expect(subject.arguments).to include('--verbose=5')
       end
 
+      it 'authorization' do
+        expect(subject.arguments).
+          to include('--http-request-header=Authorization: ApiKey test_api_key')
+      end
+
       it 'hets-libdirs' do
         expect(subject.arguments).to include("--hets-libdirs=#{libdir}")
       end


### PR DESCRIPTION
This is the HetsAgent-part of https://github.com/ontohub/ontohub-backend/issues/181.

The key used in the default settings is the one that's added in the backend's seeds.