### PR TITLE
Add RabbitMQ prefix and exchange options.

### DIFF
--- a/bin/hets_agent
+++ b/bin/hets_agent
@@ -19,7 +19,8 @@ HetsAgent::Application.boot
 # properly.
 require 'hets-agent/worker'
 
-Sneakers.configure(connection: HetsAgent::Application.bunny)
+Sneakers.configure(connection: HetsAgent::Application.bunny,
+                   exchange: ::Settings.rabbitmq.exchange)
 Sneakers.logger.level = Logger::WARN
 runner = Sneakers::Runner.new([HetsAgent::Worker], Settings.sneakers)
 runner.run

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,8 @@ rabbitmq:
   port: 5672
   username: guest
   password: guest
+  prefix: ontohub
+  exchange: ontohub
 
 sneakers:
   workers: 1

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,3 @@
+rabbitmq:
+  prefix: ontohub_development
+  exchange: ontohub_development

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,5 +10,7 @@ backend:
 rabbitmq:
   host: '::1'
   port: 25672
-  username: 'tester'
-  password: 'testing'
+  username: tester
+  password: testing
+  prefix: hets_agent_test
+  exchange: hets_agent_test

--- a/lib/hets-agent/application.rb
+++ b/lib/hets-agent/application.rb
@@ -57,7 +57,8 @@ module HetsAgent
 
       def initialize_version_requirement
         @hets_version_requirement =
-          HetsAgent::VersionRequirementRetriever.new.call
+          HetsAgent::VersionRequirementRetriever.
+          new("#{Settings.rabbitmq.exchange}_hets_version_requirement").call
 
         return unless hets_version_requirement.nil?
 

--- a/lib/hets-agent/version_requirement_retriever.rb
+++ b/lib/hets-agent/version_requirement_retriever.rb
@@ -5,11 +5,10 @@ require 'bunny'
 module HetsAgent
   # Retrieves the version requirement of Hets from the backend.
   class VersionRequirementRetriever
-    EXCHANGE_NAME = 'ex_hets_version_requirement'
+    attr_reader :connection, :exchange_name
 
-    attr_reader :connection
-
-    def initialize
+    def initialize(exchange_name)
+      @exchange_name = exchange_name
       @connection = HetsAgent::Application.bunny
     end
 
@@ -36,7 +35,7 @@ module HetsAgent
     end
 
     def link_to_exchange(channel)
-      channel.exchange(EXCHANGE_NAME,
+      channel.exchange(@exchange_name,
                        type: 'x-recent-history',
                        durable: true,
                        arguments: {'x-recent-history-length' => 1})
@@ -44,7 +43,7 @@ module HetsAgent
 
     def setup_version_requirement_queue(channel)
       queue = channel.queue(queue_name, auto_delete: true)
-      queue.bind(EXCHANGE_NAME)
+      queue.bind(@exchange_name)
       queue
     end
 

--- a/lib/hets-agent/worker.rb
+++ b/lib/hets-agent/worker.rb
@@ -9,7 +9,8 @@ module HetsAgent
   # properly.
   class Worker
     include Sneakers::Worker
-    from_queue "hets #{HetsAgent::Application.hets_version_requirement}",
+    from_queue "#{Settings.rabbitmq.prefix}_"\
+               "hets #{HetsAgent::Application.hets_version_requirement}",
                timeout_job_after: nil
 
     def work(message)

--- a/spec/lib/version_requirement_retriever_spec.rb
+++ b/spec/lib/version_requirement_retriever_spec.rb
@@ -13,7 +13,10 @@ describe HetsAgent::VersionRequirementRetriever do
     boot_application(stub_version_requirement_retriever: false)
   end
 
-  subject { HetsAgent::VersionRequirementRetriever.new }
+  subject do
+    HetsAgent::VersionRequirementRetriever.
+      new("#{Settings.rabbitmq.exchange}_hets_version_requirement")
+  end
   let(:bunny_mock) { HetsAgent::Application.bunny }
 
   context 'connection' do

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'hets-agent/worker'
 require 'ostruct'
 
-describe HetsAgent::Worker do
+describe 'HetsAgent::Worker' do
   before do
     boot_application
+    require 'hets-agent/worker'
     allow(Sneakers).to receive(:publish)
   end
 

--- a/spec/support/booting_helper.rb
+++ b/spec/support/booting_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'ostruct'
+require 'sneakers'
 
 # Helper methods for booting the application
 module BootingHelper


### PR DESCRIPTION
This adds an option for prefixing queue names and an option for the exchange name.