### PR TITLE
Use the same rubocop config across all repositories.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,7 @@ AllCops:
     - 'node_modules/**/*'
     - 'spec/dummy/**/*'
     - 'vendor/**/*'
+    - 'repos/**/*'
   # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress
   # Cop names are not displayed in offense messages by default. Change behavior

--- a/.rubocop_modified.yml
+++ b/.rubocop_modified.yml
@@ -12,6 +12,7 @@ Metrics/LineLength:
   Exclude:
     - 'app/graphql/**/*_enum.rb'
     - 'config/initializers/devise.rb'
+    - 'features/steps/**/*.rb'
 
 Layout/AlignParameters:
   Enabled: false
@@ -21,6 +22,12 @@ Layout/DotPosition:
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+
+Style/GlobalVars:
+  Exclude:
+    - 'features/steps/**/*.rb'
+    - 'features/support/aruba.rb'
+    - 'features/support/hooks.rb'
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:


### PR DESCRIPTION
We should use the same rubocop config across all repositories.