### PR TITLE
Accept and pass args in constructor

### DIFF
--- a/lib/hets-agent/worker.rb
+++ b/lib/hets-agent/worker.rb
@@ -15,8 +15,8 @@ module HetsAgent
 
     attr_reader :connection
 
-    def initialize
-      super
+    def initialize(*args)
+      super(*args)
       @connection = HetsAgent::Application.bunny
     end
 


### PR DESCRIPTION
Fixes

```
Unexpected error wrong number of arguments (given 3, expected 0)
  hets-agent/lib/hets-agent/worker.rb:18:in `initialize'
```